### PR TITLE
HIPPLUG-1606 Add "followRedirects" and "useSystemProperties" options …

### DIFF
--- a/src/main/java/org/tuckey/web/filters/urlrewrite/Conf.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/Conf.java
@@ -256,6 +256,8 @@ public class Conf {
                 rule.setQueryStringAppend(getAttrValue(toNode, "qsappend"));
                 rule.setDropCookies("true".equals(getAttrValue(toNode, "drop-cookies")));
                 if ("true".equalsIgnoreCase(getAttrValue(toNode, "encode"))) rule.setEncodeToUrl(true);
+                rule.setFollowRedirects("true".equals(getAttrValue(toNode, "followRedirects")));
+                rule.setUseSystemProperties("true".equals((getAttrValue(toNode, "useSystemProperties"))));
 
                 processSetAttributes(ruleElement, rule);
 

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRewrittenUrl.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRewrittenUrl.java
@@ -69,6 +69,8 @@ public class NormalRewrittenUrl implements RewrittenUrl {
     private boolean stopFilterChain = false;
     private boolean noSubstitution = false;
     private boolean dropCookies = true;
+    private boolean followRedirects = true;
+    private boolean useSystemProperties = false;
     private RewriteMatch rewriteMatch;
     private ServletContext targetContext = null;
 
@@ -84,6 +86,8 @@ public class NormalRewrittenUrl implements RewrittenUrl {
         this.rewriteMatch = ruleExecutionOutput.getRewriteMatch();
         this.noSubstitution = ruleExecutionOutput.isNoSubstitution();
         this.dropCookies = ruleExecutionOutput.isDropCookies();
+        this.followRedirects = ruleExecutionOutput.isFollowRedirects();
+        this.useSystemProperties = ruleExecutionOutput.isUseSystemProperties();
     }
 
     /**
@@ -289,7 +293,7 @@ public class NormalRewrittenUrl implements RewrittenUrl {
             if (hsResponse.isCommitted()) {
                 log.error("response is committed. cannot proxy " + target + ". Check that you haven't written to the response before.");
             } else {
-                RequestProxy.execute(target, hsRequest, hsResponse, dropCookies);
+                RequestProxy.execute(target, hsRequest, hsResponse, dropCookies, followRedirects, useSystemProperties);
                 if (log.isTraceEnabled()) {
                     log.trace("Proxied request to " + target);
                 }
@@ -330,6 +334,5 @@ public class NormalRewrittenUrl implements RewrittenUrl {
     public void setNoSubstitution(boolean noSubstitution) {
         this.noSubstitution = noSubstitution;
     }
-
 
 }

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRule.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRule.java
@@ -71,6 +71,8 @@ public class NormalRule extends RuleBase implements Rule {
     private boolean queryStringAppend = false;
     private String toContextStr = null;
     private ServletContext toServletContext = null;
+    private boolean followRedirects = false;
+    private boolean useSystemProperties = false;
 
     /**
      * Will run the rule against the uri and perform action required will return false is not matched
@@ -95,6 +97,8 @@ public class NormalRule extends RuleBase implements Rule {
             }
         }
         if ( toServletContext != null ) ruleExecutionOutput.setReplacedUrlContext(toServletContext);
+        ruleExecutionOutput.setFollowRedirects(followRedirects);
+        ruleExecutionOutput.setUseSystemProperties(useSystemProperties);
         return RuleExecutionOutput.getRewritenUrl(toType, encodeToUrl, ruleExecutionOutput);
     }
 
@@ -229,5 +233,13 @@ public class NormalRule extends RuleBase implements Rule {
 
     public void setDropCookies(final boolean dropCookies) {
         this.dropCookies = dropCookies;
+    }
+
+    public void setFollowRedirects(final boolean followRedirects){
+        this.followRedirects = followRedirects;
+    }
+
+    public void setUseSystemProperties(boolean useSystemProperties) {
+        this.useSystemProperties = useSystemProperties;
     }
 }

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/RuleExecutionOutput.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/RuleExecutionOutput.java
@@ -51,6 +51,8 @@ public class RuleExecutionOutput {
     private boolean noSubstitution = false;
     private RewriteMatch rewriteMatch;
     private boolean dropCookies = true;
+    private boolean followRedirects = false;
+    private boolean useSystemProperties = false;
 
     /**
      * Will perform the action defined by the rule ie, redirect or passthrough.
@@ -178,4 +180,21 @@ public class RuleExecutionOutput {
     public void setDropCookies(final boolean dropCookies) {
         this.dropCookies = dropCookies;
     }
+
+    public void setFollowRedirects(final boolean followRedirects) {
+        this.followRedirects = followRedirects;
+    }
+
+    public boolean isFollowRedirects() {
+        return followRedirects;
+    }
+
+    public void setUseSystemProperties(final boolean useSystemProperties) {
+        this.useSystemProperties = useSystemProperties;
+    }
+
+    public boolean isUseSystemProperties() {
+        return useSystemProperties;
+    }
 }
+


### PR DESCRIPTION
Add "followRedirects" and "useSystemProperties" options on <to type=proxy> element. An example url rewrite rule is as follows: 
```xml
<rule>
<from>^/_cmsinternal/resourceapi(.*)$</from>
<to last="true">-</to>
</rule>
<rule>
<from>^/_cmsinternal/binaries(.*)$</from>
<to last="true">-</to>
</rule>
<rule>
<from>^/_cmsinternal(.*)$</from>
<to type="proxy" followRedirects="true" useSystemProperties="true">https://httpbin.org/redirect-to?url=https://www.bloomreach.com</to>
</rule>
```
Issue reference: https://issues.onehippo.com/browse/HIPPLUG-1606