### PR TITLE
Add X-Forwarded-For proxy header

### DIFF
--- a/src/main/java/org/tuckey/web/filters/urlrewrite/Conf.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/Conf.java
@@ -57,7 +57,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -258,10 +257,7 @@ public class Conf {
                 if ("true".equalsIgnoreCase(getAttrValue(toNode, "encode"))) rule.setEncodeToUrl(true);
                 rule.setFollowRedirects("true".equals(getAttrValue(toNode, "followRedirects")));
                 rule.setUseSystemProperties("true".equals((getAttrValue(toNode, "useSystemProperties"))));
-                String proxyHeaders = getAttrValue(toNode, "add-proxy-headers");
-                if (!StringUtils.isBlank(proxyHeaders)) {
-                    rule.setAddProxyHeaders(Arrays.asList(proxyHeaders.split("[, ]+")));
-                }
+                rule.setProxyHeadersStr(getAttrValue(toNode, "proxy-headers"));
 
                 processSetAttributes(ruleElement, rule);
 

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/Conf.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/Conf.java
@@ -34,20 +34,6 @@
  */
 package org.tuckey.web.filters.urlrewrite;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
-import javax.servlet.ServletContext;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
 import org.tuckey.web.filters.urlrewrite.gzip.GzipFilter;
 import org.tuckey.web.filters.urlrewrite.utils.Log;
 import org.tuckey.web.filters.urlrewrite.utils.ModRewriteConfLoader;
@@ -60,6 +46,19 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 import org.xml.sax.SAXParseException;
+
+import javax.servlet.ServletContext;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Configuration object for urlrewrite filter.
@@ -258,6 +257,7 @@ public class Conf {
                 if ("true".equalsIgnoreCase(getAttrValue(toNode, "encode"))) rule.setEncodeToUrl(true);
                 rule.setFollowRedirects("true".equals(getAttrValue(toNode, "followRedirects")));
                 rule.setUseSystemProperties("true".equals((getAttrValue(toNode, "useSystemProperties"))));
+                rule.setAddProxyHeaders("true".equals((getAttrValue(toNode, "add-proxy-headers"))));
 
                 processSetAttributes(ruleElement, rule);
 

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/Conf.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/Conf.java
@@ -57,6 +57,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -257,7 +258,10 @@ public class Conf {
                 if ("true".equalsIgnoreCase(getAttrValue(toNode, "encode"))) rule.setEncodeToUrl(true);
                 rule.setFollowRedirects("true".equals(getAttrValue(toNode, "followRedirects")));
                 rule.setUseSystemProperties("true".equals((getAttrValue(toNode, "useSystemProperties"))));
-                rule.setAddProxyHeaders("true".equals((getAttrValue(toNode, "add-proxy-headers"))));
+                String proxyHeaders = getAttrValue(toNode, "add-proxy-headers");
+                if (!StringUtils.isBlank(proxyHeaders)) {
+                    rule.setAddProxyHeaders(Arrays.asList(proxyHeaders.split("[, ]+")));
+                }
 
                 processSetAttributes(ruleElement, rule);
 

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRewrittenUrl.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRewrittenUrl.java
@@ -73,7 +73,7 @@ public class NormalRewrittenUrl implements RewrittenUrl {
     private boolean dropCookies = true;
     private boolean followRedirects = true;
     private boolean useSystemProperties = false;
-    private List<String> addProxyHeaders = Collections.emptyList();
+    private List<ProxyHeaders> proxyHeaders = Collections.emptyList();
     private RewriteMatch rewriteMatch;
     private ServletContext targetContext = null;
 
@@ -91,7 +91,7 @@ public class NormalRewrittenUrl implements RewrittenUrl {
         this.dropCookies = ruleExecutionOutput.isDropCookies();
         this.followRedirects = ruleExecutionOutput.isFollowRedirects();
         this.useSystemProperties = ruleExecutionOutput.isUseSystemProperties();
-        this.addProxyHeaders = ruleExecutionOutput.getAddProxyHeaders();
+        this.proxyHeaders = ruleExecutionOutput.getProxyHeaders();
     }
 
     /**
@@ -297,7 +297,7 @@ public class NormalRewrittenUrl implements RewrittenUrl {
             if (hsResponse.isCommitted()) {
                 log.error("response is committed. cannot proxy " + target + ". Check that you haven't written to the response before.");
             } else {
-                RequestProxy.execute(target, hsRequest, hsResponse, dropCookies, followRedirects, useSystemProperties, addProxyHeaders);
+                RequestProxy.execute(target, hsRequest, hsResponse, dropCookies, followRedirects, useSystemProperties, proxyHeaders);
                 if (log.isTraceEnabled()) {
                     log.trace("Proxied request to " + target);
                 }

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRewrittenUrl.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRewrittenUrl.java
@@ -71,6 +71,7 @@ public class NormalRewrittenUrl implements RewrittenUrl {
     private boolean dropCookies = true;
     private boolean followRedirects = true;
     private boolean useSystemProperties = false;
+    private boolean addProxyHeaders = false;
     private RewriteMatch rewriteMatch;
     private ServletContext targetContext = null;
 
@@ -88,6 +89,7 @@ public class NormalRewrittenUrl implements RewrittenUrl {
         this.dropCookies = ruleExecutionOutput.isDropCookies();
         this.followRedirects = ruleExecutionOutput.isFollowRedirects();
         this.useSystemProperties = ruleExecutionOutput.isUseSystemProperties();
+        this.addProxyHeaders = ruleExecutionOutput.isAddProxyHeaders();
     }
 
     /**

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRewrittenUrl.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRewrittenUrl.java
@@ -295,7 +295,7 @@ public class NormalRewrittenUrl implements RewrittenUrl {
             if (hsResponse.isCommitted()) {
                 log.error("response is committed. cannot proxy " + target + ". Check that you haven't written to the response before.");
             } else {
-                RequestProxy.execute(target, hsRequest, hsResponse, dropCookies, followRedirects, useSystemProperties);
+                RequestProxy.execute(target, hsRequest, hsResponse, dropCookies, followRedirects, useSystemProperties, addProxyHeaders);
                 if (log.isTraceEnabled()) {
                     log.trace("Proxied request to " + target);
                 }

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRewrittenUrl.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRewrittenUrl.java
@@ -45,6 +45,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 
 /**
@@ -71,7 +73,7 @@ public class NormalRewrittenUrl implements RewrittenUrl {
     private boolean dropCookies = true;
     private boolean followRedirects = true;
     private boolean useSystemProperties = false;
-    private boolean addProxyHeaders = false;
+    private List<String> addProxyHeaders = Collections.emptyList();
     private RewriteMatch rewriteMatch;
     private ServletContext targetContext = null;
 
@@ -89,7 +91,7 @@ public class NormalRewrittenUrl implements RewrittenUrl {
         this.dropCookies = ruleExecutionOutput.isDropCookies();
         this.followRedirects = ruleExecutionOutput.isFollowRedirects();
         this.useSystemProperties = ruleExecutionOutput.isUseSystemProperties();
-        this.addProxyHeaders = ruleExecutionOutput.isAddProxyHeaders();
+        this.addProxyHeaders = ruleExecutionOutput.getAddProxyHeaders();
     }
 
     /**

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRule.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRule.java
@@ -43,6 +43,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.List;
 
 
 /**
@@ -73,7 +75,7 @@ public class NormalRule extends RuleBase implements Rule {
     private ServletContext toServletContext = null;
     private boolean followRedirects = false;
     private boolean useSystemProperties = false;
-    private boolean addProxyHeaders = false;
+    private List<String> addProxyHeaders = Collections.emptyList();
 
     /**
      * Will run the rule against the uri and perform action required will return false is not matched
@@ -245,7 +247,7 @@ public class NormalRule extends RuleBase implements Rule {
         this.useSystemProperties = useSystemProperties;
     }
 
-    public void setAddProxyHeaders(boolean addProxyHeaders) {
+    public void setAddProxyHeaders(List<String> addProxyHeaders) {
         this.addProxyHeaders = addProxyHeaders;
     }
 }

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRule.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/NormalRule.java
@@ -73,6 +73,7 @@ public class NormalRule extends RuleBase implements Rule {
     private ServletContext toServletContext = null;
     private boolean followRedirects = false;
     private boolean useSystemProperties = false;
+    private boolean addProxyHeaders = false;
 
     /**
      * Will run the rule against the uri and perform action required will return false is not matched
@@ -99,6 +100,7 @@ public class NormalRule extends RuleBase implements Rule {
         if ( toServletContext != null ) ruleExecutionOutput.setReplacedUrlContext(toServletContext);
         ruleExecutionOutput.setFollowRedirects(followRedirects);
         ruleExecutionOutput.setUseSystemProperties(useSystemProperties);
+        ruleExecutionOutput.setAddProxyHeaders(addProxyHeaders);
         return RuleExecutionOutput.getRewritenUrl(toType, encodeToUrl, ruleExecutionOutput);
     }
 
@@ -241,5 +243,9 @@ public class NormalRule extends RuleBase implements Rule {
 
     public void setUseSystemProperties(boolean useSystemProperties) {
         this.useSystemProperties = useSystemProperties;
+    }
+
+    public void setAddProxyHeaders(boolean addProxyHeaders) {
+        this.addProxyHeaders = addProxyHeaders;
     }
 }

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/ProxyHeaders.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/ProxyHeaders.java
@@ -32,7 +32,16 @@ public enum ProxyHeaders {
      *
      * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto">MDN: X-Forwarded-Proto</a>
      */
-    X_FORWARDED_PROTO("X-Forwarded-Proto");
+    X_FORWARDED_PROTO("X-Forwarded-Proto"),
+    /**
+     * When used, the system will track the original client-directed context URI for the request. This is the context prefix path for which cookies, redirects, links, and similar content should be written.
+     *
+     * @see <a href="https://github.com/spring-projects/spring-framework/blob/7cf1ccc41540752a16e370b5dd353b94108ebf22/spring-web/src/main/java/org/springframework/web/filter/ForwardedHeaderFilter.java#L346">ForwardedHeaderFilter (Spring's handling of X-Forwarded-Prefix)</a>
+     * @see <a href="https://docs.humio.com/integrations/proxies/nginx/">Humio NGINX reverse proxy integration (example X-Forwarded-Prefix usage)</a>
+     * @see <a href="https://docs.traefik.io/middlewares/stripprefix/">Traefik "StripPrefix" middleware (example X-Forwarded-Prefix usage)</a>
+     * @see <a href="https://github.com/envoyproxy/envoy/issues/5528">Requested X-Forwarded-Prefix for Envoy</a>
+     */
+    X_FORWARDED_PREFIX("X-Forwarded-Prefix");
 
     public static final String INCLUDE_ALL = "All";
 

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/ProxyHeaders.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/ProxyHeaders.java
@@ -1,0 +1,48 @@
+package org.tuckey.web.filters.urlrewrite;
+
+/**
+ * The {@link ProxyHeaders} enum declares available headers which can be propagated when proxying requests.
+ *
+ * @author Mike Hill
+ */
+public enum ProxyHeaders {
+
+    /**
+     * When used, the system will continue to propagate the existing "Host" value from the original request. Otherwise, this header will be changed to the proxy target's host name.
+     */
+    HOST("Host"),
+    /**
+     * When used, the system will populate the list of proxy hops. E.g., {@code X-Forwarded-By: <Proxy 1 Host>, <Proxy 2 Host>, ...}.
+     */
+    X_FORWARDED_BY("X-Forwarded-By"),
+    /**
+     * When used, the system will track the origin IP and all proxy IPs for the request. E.g., {@code X-Forwarded-For: <Client IP>, <Proxy 1 IP>, <Proxy 2 IP>, ...}.
+     *
+     * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For">MDN: X-Forwarded-For</a>
+     */
+    X_FORWARDED_FOR("X-Forwarded-For"),
+    /**
+     * When used, the system will track the original client-directed "Host" value for the request.
+     *
+     * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host">MDN: X-Forwarded-Host</a>
+     */
+    X_FORWARDED_HOST("X-Forwarded-Host"),
+    /**
+     * When used, the system will track the original client-directed scheme for the request.
+     *
+     * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto">MDN: X-Forwarded-Proto</a>
+     */
+    X_FORWARDED_PROTO("X-Forwarded-Proto");
+
+    public static final String INCLUDE_ALL = "All";
+
+    private final String headerName;
+
+    ProxyHeaders(String headerName) {
+        this.headerName = headerName;
+    }
+
+    public String getHeaderName() {
+        return this.headerName;
+    }
+}

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/RequestProxy.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/RequestProxy.java
@@ -288,15 +288,12 @@ public final class RequestProxy {
         // Generate proxy headers
         if (addProxyHeaders) {
             String xForwardedForHeader = X_FORWARDED_FOR;
-            String xForwardedForValue = hsRequest.getHeader(xForwardedForHeader);
-            if (xForwardedForValue == null) {
-                xForwardedForValue = hsRequest.getRemoteAddr();
-            } else {
-                final String clientAddr = xForwardedForValue.split(",\\s*")[0].trim();
-                if (!clientAddr.isEmpty()) {
-                    xForwardedForValue += ", " + clientAddr;
-                }
-            }
+            String currentXForwardedForValue = hsRequest.getHeader(xForwardedForHeader);
+            String currentRemoteAddr = hsRequest.getRemoteAddr();
+            // Expected format: "X-Forwarded-For: <Real Client IP>, <Proxy 1 IP>, <Proxy 2 IP>, ..."
+            String xForwardedForValue = !StringUtils.isBlank(currentXForwardedForValue)
+                    ? currentXForwardedForValue + ", " + currentRemoteAddr
+                    : currentRemoteAddr;
             log.info("setting proxy request parameter (add-proxy-headers): " + xForwardedForHeader + ", value: " + xForwardedForValue);
             method.addHeader(xForwardedForHeader, xForwardedForValue);
         }

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/RequestProxy.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/RequestProxy.java
@@ -326,6 +326,12 @@ public final class RequestProxy {
                     newHeaderValue = StringUtils.isBlank(existingHeaderValue) ? originalRequest.getScheme() : existingHeaderValue;
                     setRequestHeader(request, header.getHeaderName(), newHeaderValue);
                     break;
+                case X_FORWARDED_PREFIX:
+                    // Use current request value or propagate existing header if present
+                    existingHeaderValue = originalRequest.getHeader(header.getHeaderName());
+                    newHeaderValue = StringUtils.isBlank(existingHeaderValue) ? originalRequest.getContextPath() : existingHeaderValue;
+                    setRequestHeader(request, header.getHeaderName(), newHeaderValue);
+                    break;
                 default:
                     log.warn("Unexpected proxy header name of \"" + header.getHeaderName() + "\". This header name is not supported.");
             }

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/RuleExecutionOutput.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/RuleExecutionOutput.java
@@ -53,6 +53,7 @@ public class RuleExecutionOutput {
     private boolean dropCookies = true;
     private boolean followRedirects = false;
     private boolean useSystemProperties = false;
+    private boolean addProxyHeaders = false;
 
     /**
      * Will perform the action defined by the rule ie, redirect or passthrough.
@@ -195,6 +196,14 @@ public class RuleExecutionOutput {
 
     public boolean isUseSystemProperties() {
         return useSystemProperties;
+    }
+
+    public void setAddProxyHeaders(final boolean addProxyHeaders) {
+        this.addProxyHeaders = addProxyHeaders;
+    }
+
+    public boolean isAddProxyHeaders() {
+        return addProxyHeaders;
     }
 }
 

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/RuleExecutionOutput.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/RuleExecutionOutput.java
@@ -38,6 +38,8 @@ import org.tuckey.web.filters.urlrewrite.extend.RewriteMatch;
 import org.tuckey.web.filters.urlrewrite.utils.Log;
 
 import javax.servlet.ServletContext;
+import java.util.Collections;
+import java.util.List;
 
 
 public class RuleExecutionOutput {
@@ -53,7 +55,7 @@ public class RuleExecutionOutput {
     private boolean dropCookies = true;
     private boolean followRedirects = false;
     private boolean useSystemProperties = false;
-    private boolean addProxyHeaders = false;
+    private List<String> addProxyHeaders = Collections.emptyList();
 
     /**
      * Will perform the action defined by the rule ie, redirect or passthrough.
@@ -198,11 +200,11 @@ public class RuleExecutionOutput {
         return useSystemProperties;
     }
 
-    public void setAddProxyHeaders(final boolean addProxyHeaders) {
+    public void setAddProxyHeaders(final List<String> addProxyHeaders) {
         this.addProxyHeaders = addProxyHeaders;
     }
 
-    public boolean isAddProxyHeaders() {
+    public List<String> getAddProxyHeaders() {
         return addProxyHeaders;
     }
 }

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/RuleExecutionOutput.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/RuleExecutionOutput.java
@@ -55,7 +55,7 @@ public class RuleExecutionOutput {
     private boolean dropCookies = true;
     private boolean followRedirects = false;
     private boolean useSystemProperties = false;
-    private List<String> addProxyHeaders = Collections.emptyList();
+    private List<ProxyHeaders> proxyHeaders = Collections.emptyList();
 
     /**
      * Will perform the action defined by the rule ie, redirect or passthrough.
@@ -200,12 +200,12 @@ public class RuleExecutionOutput {
         return useSystemProperties;
     }
 
-    public void setAddProxyHeaders(final List<String> addProxyHeaders) {
-        this.addProxyHeaders = addProxyHeaders;
+    public List<ProxyHeaders> getProxyHeaders() {
+        return this.proxyHeaders;
     }
 
-    public List<String> getAddProxyHeaders() {
-        return addProxyHeaders;
+    public void setProxyHeaders(List<ProxyHeaders> proxyHeaders) {
+        this.proxyHeaders = proxyHeaders;
     }
 }
 

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/Status.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/Status.java
@@ -275,6 +275,14 @@ public class Status {
                 }
                 println(".</p>");
                 print("<p>This rule and it's conditions will use the <code>" + normalRule.getMatchType() + "</code> matching engine.</p>");
+                if (!normalRule.getProxyHeaders().isEmpty()) {
+                    println("<p>This rule will automatically assign the following proxy headers to all proxied requests:<ul>");
+                    for (ProxyHeaders header : normalRule.getProxyHeaders()){
+                        println("<li>" + header.getHeaderName() + "</li>");
+                    }
+                    println("</ul></p>");
+                }
+
                 showConditions(normalRule);
                 showSets(normalRule);
                 showRuns(normalRule);

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/Status.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/Status.java
@@ -43,10 +43,7 @@ import javax.servlet.http.HttpSession;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.List;
+import java.util.*;
 
 /**
  * Outputs information about urlrewritefilter.
@@ -277,7 +274,9 @@ public class Status {
                 print("<p>This rule and it's conditions will use the <code>" + normalRule.getMatchType() + "</code> matching engine.</p>");
                 if (!normalRule.getProxyHeaders().isEmpty()) {
                     println("<p>This rule will automatically assign the following proxy headers to all proxied requests:<ul>");
-                    for (ProxyHeaders header : normalRule.getProxyHeaders()){
+                    List<ProxyHeaders> sortedProxyHeaders = normalRule.getProxyHeaders();
+                    sortedProxyHeaders.sort(Comparator.comparing(ProxyHeaders::getHeaderName));
+                    for (ProxyHeaders header : sortedProxyHeaders){
                         println("<li>" + header.getHeaderName() + "</li>");
                     }
                     println("</ul></p>");

--- a/src/main/resources/org/tuckey/web/filters/urlrewrite/dtds/urlrewrite4.0.dtd
+++ b/src/main/resources/org/tuckey/web/filters/urlrewrite/dtds/urlrewrite4.0.dtd
@@ -54,19 +54,20 @@ type (request|session|response-header|cookie|content-type|charset|locale|status|
 name CDATA  #IMPLIED
 >
 
-<!-- Supported comma-delimited add-proxy-header values (case-sensitive): Host, X-Forwarded-By, X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto -->
 <!ELEMENT to (#PCDATA)>
-<!ATTLIST to
-type (redirect|temporary-redirect|permanent-redirect|pre-include|post-include|forward|passthrough|proxy) "forward"
-last (true|false) "false"
-qsappend (true|false) "false"
-drop-cookies (true|false) "false"
-followRedirects (true|false) "false"
-useSystemProperties (true|false) "false"
-add-proxy-headers CDATA #IMPLIED
-encode (true|false) #IMPLIED
-context CDATA  #IMPLIED
->
+<!ATTLIST to type (redirect|temporary-redirect|permanent-redirect|pre-include|post-include|forward|passthrough|proxy) "forward">
+<!ATTLIST to last (true|false) "false" >
+<!ATTLIST to qsappend (true|false) "false">
+<!ATTLIST to drop-cookies (true|false) "false" >
+<!ATTLIST to followRedirects (true|false) "false" >
+<!ATTLIST to useSystemProperties (true|false) "false" >
+<!--
+	The list of headers to be added to proxy requests, in addition to propagating the original request headers. Supported comma-delimited values:
+	All, Host, X-Forwarded-By, X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto
+-->
+<!ATTLIST to proxy-headers CDATA #IMPLIED >
+<!ATTLIST to encode (true|false) #IMPLIED >
+<!ATTLIST to context CDATA  #IMPLIED>
 
 <!--
 eg,

--- a/src/main/resources/org/tuckey/web/filters/urlrewrite/dtds/urlrewrite4.0.dtd
+++ b/src/main/resources/org/tuckey/web/filters/urlrewrite/dtds/urlrewrite4.0.dtd
@@ -62,7 +62,7 @@ qsappend (true|false) "false"
 drop-cookies (true|false) "false"
 followRedirects (true|false) "false"
 useSystemProperties (true|false) "false"
-add-proxy-headers (true|false) "false"
+add-proxy-headers CDATA #IMPLIED
 encode (true|false) #IMPLIED
 context CDATA  #IMPLIED
 >

--- a/src/main/resources/org/tuckey/web/filters/urlrewrite/dtds/urlrewrite4.0.dtd
+++ b/src/main/resources/org/tuckey/web/filters/urlrewrite/dtds/urlrewrite4.0.dtd
@@ -62,6 +62,7 @@ qsappend (true|false) "false"
 drop-cookies (true|false) "false"
 followRedirects (true|false) "false"
 useSystemProperties (true|false) "false"
+add-proxy-headers (true|false) "false"
 encode (true|false) #IMPLIED
 context CDATA  #IMPLIED
 >

--- a/src/main/resources/org/tuckey/web/filters/urlrewrite/dtds/urlrewrite4.0.dtd
+++ b/src/main/resources/org/tuckey/web/filters/urlrewrite/dtds/urlrewrite4.0.dtd
@@ -63,7 +63,7 @@ name CDATA  #IMPLIED
 <!ATTLIST to useSystemProperties (true|false) "false" >
 <!--
 	The list of headers to be added to proxy requests, in addition to propagating the original request headers. Supported comma-delimited values:
-	All, Host, X-Forwarded-By, X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto
+	All, Host, X-Forwarded-By, X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto, X-Forwarded-Prefix
 -->
 <!ATTLIST to proxy-headers CDATA #IMPLIED >
 <!ATTLIST to encode (true|false) #IMPLIED >

--- a/src/main/resources/org/tuckey/web/filters/urlrewrite/dtds/urlrewrite4.0.dtd
+++ b/src/main/resources/org/tuckey/web/filters/urlrewrite/dtds/urlrewrite4.0.dtd
@@ -54,6 +54,7 @@ type (request|session|response-header|cookie|content-type|charset|locale|status|
 name CDATA  #IMPLIED
 >
 
+<!-- Supported comma-delimited add-proxy-header values (case-sensitive): Host, X-Forwarded-By, X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto -->
 <!ELEMENT to (#PCDATA)>
 <!ATTLIST to
 type (redirect|temporary-redirect|permanent-redirect|pre-include|post-include|forward|passthrough|proxy) "forward"

--- a/src/main/resources/org/tuckey/web/filters/urlrewrite/dtds/urlrewrite4.0.dtd
+++ b/src/main/resources/org/tuckey/web/filters/urlrewrite/dtds/urlrewrite4.0.dtd
@@ -60,6 +60,8 @@ type (redirect|temporary-redirect|permanent-redirect|pre-include|post-include|fo
 last (true|false) "false"
 qsappend (true|false) "false"
 drop-cookies (true|false) "false"
+followRedirects (true|false) "false"
+useSystemProperties (true|false) "false"
 encode (true|false) #IMPLIED
 context CDATA  #IMPLIED
 >

--- a/src/test/resources/org/tuckey/web/filters/urlrewrite/conf-test-bad-proxy.xml
+++ b/src/test/resources/org/tuckey/web/filters/urlrewrite/conf-test-bad-proxy.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE urlrewrite PUBLIC "-//tuckey.org//DTD UrlRewrite 4.0//EN"
+        "http://www.tuckey.org/res/dtds/urlrewrite4.0.dtd">
+
+<urlrewrite decode-using="utf-8">
+
+    <rule>
+        <name>Proxy Invalid Headers</name>
+        <from>/proxy/(.*)</from>
+        <to type="proxy" proxy-headers="Host,X-Forwarded-Host,Some-Invalid-Header">http://test.com/$1</to>
+    </rule>
+
+    <rule>
+        <name>Proxy Headers for Invalid To-Type</name>
+        <from>/proxy/(.*)</from>
+        <to type="forward" proxy-headers="Host,X-Forwarded-Host,Some-Invalid-Header">http://test.com/$1</to>
+    </rule>
+
+</urlrewrite>
+

--- a/src/test/resources/org/tuckey/web/filters/urlrewrite/conf-test1.xml
+++ b/src/test/resources/org/tuckey/web/filters/urlrewrite/conf-test1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE urlrewrite PUBLIC "-//tuckey.org//DTD UrlRewrite 3.2//EN"
-        "http://www.tuckey.org/res/dtds/urlrewrite3.2.dtd">
+<!DOCTYPE urlrewrite PUBLIC "-//tuckey.org//DTD UrlRewrite 4.0//EN"
+        "http://www.tuckey.org/res/dtds/urlrewrite4.0.dtd">
 
 <urlrewrite decode-using="utf-8">
 
@@ -76,6 +76,18 @@
     <rule>
         <from>^/lowerMe/([A-Z])+/$</from>
         <to>/lowerMe/${lower:$1}</to>
+    </rule>
+
+    <rule>
+        <name>Proxy All Headers</name>
+        <from>/proxy/(.*)</from>
+        <to type="proxy" proxy-headers="all">http://test.com/$1</to>
+    </rule>
+
+    <rule>
+        <name>Proxy Host Headers</name>
+        <from>/proxy/(.*)</from>
+        <to type="proxy" proxy-headers="Host,X-Forwarded-Host">http://test.com/$1</to>
     </rule>
 
     <outbound-rule>


### PR DESCRIPTION
Targeting this fork since it seems to be the most active of UrlRewriteFilter and has been a really helpful fork for us so far (thank you for your work!).

This tries to fix an issue into where (reverse-)proxying doesn't include the X-Forwarded-For header. This header propagates the original client IP to downstream targets. This need for us comes out of a simple (Atlassian Crowd) SSO solution that requires validating an SSO token against a matching client IP. Hosts need to see the real client IP during proxied requests rather than just the proxy (UrlRewriteFilter) server's IP.

MDN X-Forwarded-For page: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For

There seems to be some question on whether X-Forwarded-For or X-Real-IP is a better header to use ([source](https://github.com/akka/akka-http/issues/1670#issuecomment-353072461)). However, MDN doesn't list X-Real-IP, and I don't seem to see it used as often in other places. The Tomcat [RemoteIpValve](https://tomcat.apache.org/tomcat-8.5-doc/api/org/apache/catalina/valves/RemoteIpValve.html) uses X-Forwarded-For, X-Forwarded-By, and X-Forwarded-Proto only, by default. NGINX mentions X-Real-IP in some of their guides, but seems to prefer X-Forwarded-For (e.g., `$proxy_add_x_forwarded_for`). I don't see any mention of X-Real-IP in the org.apache.tomcat:tomcat-catalina:9.0.30 source.