### PR TITLE
Fix content type parsing error for HttpCore 4.4.6+

### DIFF
--- a/src/main/java/org/tuckey/web/filters/urlrewrite/RequestProxy.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/RequestProxy.java
@@ -148,7 +148,7 @@ public final class RequestProxy {
 
             if (targetRequest instanceof HttpEntityEnclosingRequestBase) {
                 final InputStreamEntity entity = new InputStreamEntity(
-                        hsRequest.getInputStream(), hsRequest.getContentLength(), ContentType.create(hsRequest.getContentType()));
+                        hsRequest.getInputStream(), hsRequest.getContentLength(), ContentType.parse(hsRequest.getContentType()));
                 final HttpEntityEnclosingRequestBase entityEnclosingMethod = (HttpEntityEnclosingRequestBase) targetRequest;
                 entityEnclosingMethod.setEntity(entity);
                 requestParam = entityEnclosingMethod;


### PR DESCRIPTION
Targeting this fork for the same reason as #5.

A bugfix in Apache HttpCore 4.4.6 ([HTTPCORE-423](https://issues.apache.org/jira/browse/HTTPCORE-423), [f8f55e88](https://github.com/apache/httpcomponents-core/commit/f8f55e88a35c4afbb088e0d17292762f74f8d251#diff-a64c63225be95b278b7bc2cfe78d9191R194)) causes UrlRewriteFilter PUT/POST requests to fail if their content type includes a charset (e.g., `Content-Type: application/json; charset=UTF-8`). This is because the `ContentType.create(String)` method used to use its parameter directly as the MIME type (incorrect behavior -- included charset in MIME type), but now tries to read it as a MIME type. The alternative factory method `ContentType.parse(String)` parses the full string for both MIME type and charset.

We didn't notice this issue until recently since we don't pull transitive dependencies for UrlRewriteFilter. A separate library update upgraded us from HttpCore v4.4.5 to v4.4.13, which fixed the `ContentType.create(String)` method but broke UrlRewriteFilter.